### PR TITLE
Add list clipboard commands and update metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Obsidian Outliner
+# List Extra Outliner
 
 ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/vslinko/obsidian-outliner/build.yml?style=for-the-badge&branch=main)
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/vslinko/obsidian-outliner?style=for-the-badge&sort=semver)
 
-**Work with your lists like in Workflowy or RoamResearch**
+**an extend to Outliner project**
 
 ⁉️ [Discuss ideas or ask a question](https://github.com/vslinko/obsidian-outliner/discussions)<br>
 ⚙️ [Follow the development process](https://github.com/users/vslinko/projects/3/views/1)<br>

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-  "id": "obsidian-outliner",
-  "name": "Outliner",
+  "id": "list-extra-outliner",
+  "name": "List Extra Outliner",
   "version": "4.9.0",
   "minAppVersion": "1.8.7",
-  "description": "Work with your lists like in Workflowy or RoamResearch.",
-  "author": "Viacheslav Slinko",
+  "description": "an extend to Outliner project",
+  "author": "sajjad abouei",
   "authorUrl": "https://github.com/vslinko",
   "isDesktopOnly": false
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "obsidian-outliner",
+  "name": "list-extra-outliner",
   "version": "4.9.0",
-  "description": "Work with your lists like in Workflowy or RoamResearch.",
+  "description": "an extend to Outliner project",
   "main": "main.js",
   "scripts": {
     "dev": "rollup --config rollup.config.mjs -w --configWithTests",
@@ -12,7 +12,7 @@
     "test:unit": "SKIP_OBSIDIAN=1 jest --forceExit src",
     "prepare": "husky"
   },
-  "author": "Viacheslav Slinko",
+  "author": "sajjad abouei",
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.26.9",

--- a/src/ObsidianOutlinerPlugin.ts
+++ b/src/ObsidianOutlinerPlugin.ts
@@ -19,6 +19,7 @@ import { SystemInfo } from "./features/SystemInfo";
 import { TabBehaviourOverride } from "./features/TabBehaviourOverride";
 import { VerticalLines } from "./features/VerticalLines";
 import { VimOBehaviourOverride } from "./features/VimOBehaviourOverride";
+import { ListClipboardCommands } from "./features/ListClipboardCommands";
 import { ChangesApplicator } from "./services/ChangesApplicator";
 import { IMEDetector } from "./services/IMEDetector";
 import { Logger } from "./services/Logger";
@@ -41,6 +42,7 @@ export default class ObsidianOutlinerPlugin extends Plugin {
   private changesApplicator: ChangesApplicator;
   private operationPerformer: OperationPerformer;
   private imeDetector: IMEDetector;
+  private clipboard = { text: "" };
 
   async onload() {
     console.log(`Loading obsidian-outliner`);
@@ -72,6 +74,12 @@ export default class ObsidianOutlinerPlugin extends Plugin {
         this.operationPerformer,
       ),
       new ListsFoldingCommands(this, this.obsidianSettings),
+      new ListClipboardCommands(
+        this,
+        this.parser,
+        this.operationPerformer,
+        this.clipboard,
+      ),
 
       // features based on settings.keepCursorWithinContent
       new EditorSelectionsBehaviourOverride(

--- a/src/features/ListClipboardCommands.ts
+++ b/src/features/ListClipboardCommands.ts
@@ -1,0 +1,60 @@
+import { Plugin } from "obsidian";
+
+import { Feature } from "./Feature";
+import { MyEditor } from "../editor";
+import { CopyList } from "../operations/CopyList";
+import { CutList } from "../operations/CutList";
+import { PasteList } from "../operations/PasteList";
+import { OperationPerformer } from "../services/OperationPerformer";
+import { Parser } from "../services/Parser";
+import { createEditorCallback } from "../utils/createEditorCallback";
+
+export class ListClipboardCommands implements Feature {
+  constructor(
+    private plugin: Plugin,
+    private parser: Parser,
+    private operationPerformer: OperationPerformer,
+    private clipboard: { text: string },
+  ) {}
+
+  async load() {
+    this.plugin.addCommand({
+      id: "copy-list-with-sublist",
+      name: "Copy list with sublist",
+      editorCallback: createEditorCallback(this.copy),
+    });
+    this.plugin.addCommand({
+      id: "cut-list-with-sublist",
+      name: "Cut list with sublist",
+      editorCallback: createEditorCallback(this.cut),
+    });
+    this.plugin.addCommand({
+      id: "paste-list-with-sublist",
+      name: "Paste list with sublist (folded)",
+      editorCallback: createEditorCallback(this.paste),
+    });
+  }
+
+  async unload() {}
+
+  private copy = (editor: MyEditor) => {
+    return this.operationPerformer.perform(
+      (root) => new CopyList(root, this.clipboard),
+      editor,
+    ).shouldStopPropagation;
+  };
+
+  private cut = (editor: MyEditor) => {
+    return this.operationPerformer.perform(
+      (root) => new CutList(root, this.clipboard),
+      editor,
+    ).shouldStopPropagation;
+  };
+
+  private paste = (editor: MyEditor) => {
+    return this.operationPerformer.perform(
+      (root) => new PasteList(root, this.clipboard, this.parser),
+      editor,
+    ).shouldStopPropagation;
+  };
+}

--- a/src/operations/CopyList.ts
+++ b/src/operations/CopyList.ts
@@ -1,0 +1,30 @@
+import { Operation } from "./Operation";
+import { Root } from "../root";
+
+export class CopyList implements Operation {
+  private stopPropagation = false;
+  private updated = false;
+
+  constructor(private root: Root, private clipboard: { text: string }) {}
+
+  shouldStopPropagation() {
+    return this.stopPropagation;
+  }
+
+  shouldUpdate() {
+    return this.updated;
+  }
+
+  perform() {
+    if (!this.root.hasSingleCursor()) {
+      return;
+    }
+
+    this.stopPropagation = true;
+    const list = this.root.getListUnderCursor();
+    this.clipboard.text = list.print().replace(/\n$/, "");
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(this.clipboard.text);
+    }
+  }
+}

--- a/src/operations/CutList.ts
+++ b/src/operations/CutList.ts
@@ -1,0 +1,37 @@
+import { Operation } from "./Operation";
+import { Root, recalculateNumericBullets } from "../root";
+
+export class CutList implements Operation {
+  private stopPropagation = false;
+  private updated = false;
+
+  constructor(private root: Root, private clipboard: { text: string }) {}
+
+  shouldStopPropagation() {
+    return this.stopPropagation;
+  }
+
+  shouldUpdate() {
+    return this.updated;
+  }
+
+  perform() {
+    if (!this.root.hasSingleCursor()) {
+      return;
+    }
+
+    this.stopPropagation = true;
+    this.updated = true;
+
+    const list = this.root.getListUnderCursor();
+    this.clipboard.text = list.print().replace(/\n$/, "");
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(this.clipboard.text);
+    }
+
+    const cursor = list.getFirstLineContentStart();
+    list.getParent().removeChild(list);
+    this.root.replaceCursor(cursor);
+    recalculateNumericBullets(this.root);
+  }
+}

--- a/src/operations/PasteList.ts
+++ b/src/operations/PasteList.ts
@@ -1,0 +1,57 @@
+import { Operation } from "./Operation";
+import { Root, recalculateNumericBullets } from "../root";
+import { Parser, Reader } from "../services/Parser";
+
+export class PasteList implements Operation {
+  private stopPropagation = false;
+  private updated = false;
+
+  constructor(
+    private root: Root,
+    private clipboard: { text: string },
+    private parser: Parser,
+  ) {}
+
+  shouldStopPropagation() {
+    return this.stopPropagation;
+  }
+
+  shouldUpdate() {
+    return this.updated;
+  }
+
+  perform() {
+    const text = this.clipboard.text;
+    if (!text || !this.root.hasSingleCursor()) {
+      return;
+    }
+
+    this.stopPropagation = true;
+
+    const lines = text.split("\n");
+    const reader: Reader = {
+      getCursor: () => ({ line: 0, ch: 0 }),
+      getLine: (n: number) => lines[n],
+      lastLine: () => lines.length - 1,
+      listSelections: () => [{ anchor: { line: 0, ch: 0 }, head: { line: 0, ch: 0 } }],
+      getAllFoldedLines: () => [],
+    };
+
+    const [clipRoot] = this.parser.parseRange(reader);
+
+    if (!clipRoot || clipRoot.getChildren().length === 0) {
+      return;
+    }
+
+    this.updated = true;
+
+    const newList = clipRoot.getChildren()[0].clone(this.root);
+    (newList as any).foldRoot = true;
+
+    const list = this.root.getListUnderCursor();
+    list.getParent().addAfter(list, newList);
+
+    this.root.replaceCursor(newList.getFirstLineContentStart());
+    recalculateNumericBullets(this.root);
+  }
+}


### PR DESCRIPTION
## Summary
- rename project to List Extra Outliner
- update description and author
- implement commands to copy, cut and paste lists along with sublists
- ensure pasted lists are folded on insert

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: rollup not found)*
- `npx tsc -p tsconfig.json` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685bc8cff444832daa3c58daa2caf971